### PR TITLE
feat: support >3 work maps via active-slot swap

### DIFF
--- a/app/src/components/StartMowSheet.tsx
+++ b/app/src/components/StartMowSheet.tsx
@@ -298,9 +298,24 @@ export function StartMowSheet({
         .map(m => m.mapId);
 
       if (orderedMapIds.length > 1) {
-        // Multi-map: hand off to the queue. The queue sends the FIRST
-        // start_navigation immediately and watches Work:FINISHED to
-        // dispatch the next.
+        // Multi-map: hand off to the queue. Pre-swap the first map so the
+        // initial start_navigation lands on the right slot. The queue
+        // performs additional swaps before each subsequent dispatch
+        // (see MowQueueContext).
+        const firstMap = maps.find(m => m.mapId === orderedMapIds[0]) ?? maps[0];
+        const firstSlot = (() => {
+          const m = (firstMap?.canonicalName ?? '').match(/^map(\d+)/);
+          return m ? parseInt(m[1], 10) : 0;
+        })();
+        try {
+          await api.setActiveMapSlot(sn, firstSlot);
+        } catch (e) {
+          console.log('[StartMow] setActiveMapSlot failed (queue head):', e);
+          const msg = e instanceof Error ? e.message : 'swap failed';
+          Alert.alert(t('startMowFailed') || 'Could not start', msg);
+          setStarting(false);
+          return;
+        }
         await api.clearTrail(sn).catch(() => {});
         await enqueue({
           sn,
@@ -314,12 +329,9 @@ export function StartMowSheet({
         return;
       }
 
-      // Single-map path (legacy, identical to pre-multi-select behaviour).
-      // Issue #14 / #18: derive the firmware `area` enum from the canonical
-      // slot identifier (map0/map1/map2) so the user's selection lines up
-      // with the mower's internal index. Sorting by updated_at + using array
-      // index produced "select front, mow trampo" because the alphabetical
-      // app order didn't match the firmware's creation order.
+      // Single-map path. Use canonicalName for the firmware slot index so
+      // we always dispatch the map the user actually picked (not the array
+      // position). Issue #14 / #18.
       const selectedMap = maps.find(m => m.mapId === orderedMapIds[0]) ?? maps[0];
       const canonicalIdx = (() => {
         const m = (selectedMap?.canonicalName ?? '').match(/^map(\d+)/);
@@ -327,9 +339,22 @@ export function StartMowSheet({
       })();
       const fallbackIdx = maps.findIndex(m => m.mapId === orderedMapIds[0]);
       const mapIdx = canonicalIdx ?? (fallbackIdx >= 0 ? fallbackIdx : 0);
-      // Firmware `area` enum: map0=1, map1=10, map2=200. Confirmed in
-      // docs/reference/MOWING-FLOW.md. Three slots only (firmware limit).
-      const areaParam = mapIdx === 0 ? 1 : mapIdx === 1 ? 10 : 200;
+
+      // Multi-map support (spec 2026-05-04): ask the server to swap the
+      // mower's active map.yaml to the selected slot before dispatching
+      // start_navigation. After a successful swap, area is irrelevant —
+      // the loaded map.yaml IS the requested map. We send area=0 to avoid
+      // the legacy 1/10/200 enum.
+      try {
+        await api.setActiveMapSlot(sn, mapIdx);
+      } catch (e) {
+        console.log('[StartMow] setActiveMapSlot failed:', e);
+        const msg = e instanceof Error ? e.message : 'swap failed';
+        Alert.alert(t('startMowFailed') || 'Could not start', msg);
+        setStarting(false);
+        return;
+      }
+      const areaParam = 0;
 
       // 0. Clear old trail from previous session
       await api.clearTrail(sn).catch(() => {});

--- a/app/src/context/MowQueueContext.tsx
+++ b/app/src/context/MowQueueContext.tsx
@@ -146,11 +146,21 @@ export function MowQueueProvider({ children }: { children: React.ReactNode }) {
       const wireHeight = Math.max(0, state.cuttingHeight - 2);
       const cmdNum = Date.now() % 100000;
       console.log(`[MowQueue] dispatch ${head.mapName} (idx=${head.mapIdx}) cutterhigh=${wireHeight}`);
+      // Multi-map support (spec 2026-05-04): swap the active map slot
+      // before each dispatch so the queue can mow ANY canonical slot,
+      // not just map0/1/2. Treat swap failure as a fatal queue error
+      // — better to abort cleanly than mow the wrong polygon.
+      try {
+        await api.setActiveMapSlot(state.sn, head.mapIdx);
+      } catch (err) {
+        console.warn(`[MowQueue] setActiveMapSlot failed for slot=${head.mapIdx}:`, err);
+        return;
+      }
       await api.sendCommand(state.sn, {
         start_navigation: {
           mapName: 'test',
+          area: 0,  // map.yaml swap above makes the legacy area enum irrelevant
           cutterhigh: wireHeight,
-          area: areaParamFromIdx(head.mapIdx),
           cmd_num: cmdNum,
         },
       });

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -345,6 +345,21 @@ export class ApiClient {
     );
   }
 
+  async setActiveMapSlot(sn: string, slot: number): Promise<{ ok: boolean; slot: number; cached?: boolean; error?: string }> {
+    return this.request<{ ok: boolean; slot: number; cached?: boolean; error?: string }>(
+      'POST',
+      `/api/dashboard/maps/${encodeURIComponent(sn)}/active-slot`,
+      { body: { slot } },
+    );
+  }
+
+  async getActiveMapSlot(sn: string): Promise<{ slot: number | null }> {
+    return this.request<{ slot: number | null }>(
+      'GET',
+      `/api/dashboard/maps/${encodeURIComponent(sn)}/active-slot`,
+    );
+  }
+
   /**
    * Register an Expo push token for a bound mower. Idempotent on the
    * server side — re-registering with the same (token, sn) is a no-op

--- a/dashboard/src/components/dashboard/MowerControls.tsx
+++ b/dashboard/src/components/dashboard/MowerControls.tsx
@@ -12,7 +12,7 @@ import {
   setDemoMode as setDemoModeApi, getDemoMode,
 } from '../../api/client';
 import { localToGps } from '../../utils/coords';
-import { mmToCutterhigh, workIndexToArea, nextCmdNum } from '../../utils/mqtt';
+import { mmToCutterhigh, nextCmdNum } from '../../utils/mqtt';
 import { useToast } from '../common/Toast';
 import { PatternPicker } from '../patterns/PatternPicker';
 import { loadPattern, transformToGps, type NormContour } from '../../utils/patternUtils.js';
@@ -281,14 +281,33 @@ export function MowerControls({
           ? workMaps.find(m => m.mapId === mapId)
           : workMaps[0];
         const mapIdx = targetMap ? workMaps.indexOf(targetMap) : 0;
-        const areaParam = workIndexToArea(Math.max(0, mapIdx));
         const resolvedMapName = targetMap?.mapName ?? 'test';
+
+        // Multi-map support (spec 2026-05-04): swap the active map slot
+        // before dispatching so the dashboard can mow any work map, not
+        // only the first 3 covered by the legacy area enum. Translate
+        // mapIdx → slot via the same parse rule the app uses.
+        try {
+          const swapRes = await fetch(`/api/dashboard/maps/${encodeURIComponent(sn)}/active-slot`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ slot: mapIdx }),
+          });
+          if (!swapRes.ok) {
+            const text = await swapRes.text().catch(() => '');
+            throw new Error(`HTTP ${swapRes.status}: ${text}`);
+          }
+        } catch (err) {
+          toast(`✗ ${t('controls.startMowing')}: swap failed (${String(err)})`, 'error');
+          setBusy(false);
+          return;
+        }
 
         const cmdNum = nextCmdNum();
         const navPayload: Record<string, unknown> = {
           mapName: resolvedMapName,
           cutterhigh: wireHeight,
-          area: areaParam,
+          area: 0,  // post-swap, map.yaml IS the requested map
           cmd_num: cmdNum,
         };
         const navResult = await sendCommand(sn, { start_navigation: navPayload });
@@ -296,7 +315,7 @@ export function MowerControls({
         if (!navResult.ok) {
           // Fallback: old firmware protocol (matches app StartMowSheet.tsx line 317)
           await sendCommand(sn, {
-            start_run: { mapName: null, area: areaParam, cutterhigh: wireHeight },
+            start_run: { mapName: null, area: 0, cutterhigh: wireHeight },
           });
         }
 

--- a/docs/superpowers/plans/2026-05-04-multi-map-swap-active-slot.md
+++ b/docs/superpowers/plans/2026-05-04-multi-map-swap-active-slot.md
@@ -1,0 +1,1046 @@
+# Multi-Map Active-Slot Swap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lift the firmware's effective 3-map limit by adding a `swap_active_map` flow that copies the right per-slot `mapN.{yaml,pgm,png}` over the active `map.*` slot + reloads the nav stack before every `start_navigation`. Server stays stateless; mower-side handler does the disk swap + ROS `LoadMap` call.
+
+**Architecture:** Mower's `extended_commands.py` gains a new handler. Server gets one new endpoint (`POST /api/dashboard/maps/:sn/active-slot`) that publishes `{swap_active_map:{slot:N}}` and awaits the ack. App + dashboard call this before any `start_navigation` whose canonical slot ≠ the cached active slot. ScheduleRunner does the same server-side. After a successful swap, `start_navigation` runs with `area: 0` because the loaded `map.yaml` IS the requested map.
+
+**Tech Stack:** TypeScript ESM (server + app), Python 3 (mower extended_commands), ROS 2 Galactic (`/map_server/load_map` service), MQTT extended-response RPC pattern (`publishToExtended` + `onExtendedResponse`).
+
+---
+
+## File Structure
+
+**Create:**
+- `server/src/__tests__/routes/dashboardActiveSlot.test.ts` — endpoint tests
+
+**Modify:**
+- `research/extended_commands.py` — add `handle_swap_active_map` + COMMANDS registration + `_coverage_is_active` reuse
+- `server/src/routes/dashboard.ts` — add POST/GET `/maps/:sn/active-slot`
+- `server/src/services/scheduleRunner.ts` — call swap before `triggerSchedule`
+- `app/src/services/api.ts` — add `setActiveMapSlot(sn, slot)`
+- `app/src/components/StartMowSheet.tsx` — call swap before single-map dispatch + multi-map enqueue
+- `app/src/context/MowQueueContext.tsx` — call swap before each per-map start
+- `dashboard/src/components/dashboard/MowerControls.tsx` — call swap from dashboard start button (optional, mirrors app)
+
+**Out of scope:**
+- App's BLE mapping screen (`MappingScreen.tsx`) does NOT change in this plan. The current cap of 3 maps in mapping is a separate UI fix; today's plan only enables MOWING on slots 3+ that already exist on the mower (e.g. user manually mapped via stock Novabot app + somehow got past UI cap, or will benefit once we lift that cap separately).
+
+---
+
+## Task 1: Mower handler — `handle_swap_active_map`
+
+**Files:**
+- Modify: `research/extended_commands.py` — add handler function + register in `COMMANDS`
+
+- [ ] **Step 1: Locate the COMMANDS dict + `_coverage_is_active` helper**
+
+Run: `grep -n "^COMMANDS\|_coverage_is_active\|def handle_sync_map" research/extended_commands.py`
+
+Expected output includes the `COMMANDS = {` line and the existing `_coverage_is_active` function (used by handle_sync_map). Both must already exist — no new helpers needed.
+
+- [ ] **Step 2: Add the handler implementation**
+
+Append this function to `research/extended_commands.py` immediately after the existing `_restart_auto_recharge_server` definition (search for that name; new function goes right after it):
+
+```python
+def handle_swap_active_map(params, respond):
+    """Copy mapN.{yaml,pgm,png} over the active map.{yaml,pgm,png} slot
+    and reload the nav stack via /map_server/load_map. Lifts the stock
+    firmware's effective 3-map limit (see docs/superpowers/specs/
+    2026-05-04-multi-map-swap-active-slot.md).
+
+    Result codes:
+      0 = success
+      1 = bad request (negative/missing slot) or copy failure
+      2 = requested slot was never mapped on this mower
+      3 = coverage is active — refuse mid-task
+      4 = files copied but LoadMap ROS call failed
+    """
+    import os
+    import shutil
+    import subprocess
+
+    slot_raw = params.get("slot", -1)
+    try:
+        slot = int(slot_raw)
+    except (TypeError, ValueError):
+        respond("swap_active_map_respond",
+                {"result": 1, "error": f"slot must be integer, got {slot_raw!r}"})
+        return
+    if slot < 0:
+        respond("swap_active_map_respond",
+                {"result": 1, "error": "slot must be non-negative"})
+        return
+
+    home = "/userdata/lfi/maps/home0"
+    src_yaml = f"{home}/map{slot}.yaml"
+    src_pgm = f"{home}/map{slot}.pgm"
+    src_png = f"{home}/map{slot}.png"
+
+    if not (os.path.exists(src_yaml) and os.path.exists(src_pgm)):
+        respond("swap_active_map_respond", {
+            "result": 2,
+            "error": f"map{slot} not mapped on this mower (yaml/pgm missing)",
+            "slot": slot,
+        })
+        return
+
+    if _coverage_is_active():
+        respond("swap_active_map_respond", {
+            "result": 3,
+            "error": "coverage active, swap refused — stop the running task first",
+            "slot": slot,
+        })
+        return
+
+    try:
+        for src, dst_name in (
+            (src_yaml, "map.yaml"),
+            (src_pgm, "map.pgm"),
+            (src_png, "map.png"),
+        ):
+            if not os.path.exists(src):
+                continue  # png is optional; yaml/pgm checked above
+            tmp = f"{home}/{dst_name}.tmp"
+            shutil.copy2(src, tmp)
+            os.replace(tmp, f"{home}/{dst_name}")
+    except Exception as e:
+        respond("swap_active_map_respond", {
+            "result": 1,
+            "error": f"copy failed: {e}",
+            "slot": slot,
+        })
+        return
+
+    cmd = (
+        ". /opt/ros/galactic/setup.bash && "
+        ". /root/novabot/install/setup.bash && "
+        "export ROS_LOCALHOST_ONLY=1 && "
+        "ros2 service call /map_server/load_map nav2_msgs/srv/LoadMap "
+        f'"{{map_url: \\"{home}/map.yaml\\"}}"'
+    )
+    try:
+        rc = subprocess.run(
+            ["bash", "-lc", cmd],
+            capture_output=True, text=True, timeout=15,
+        )
+    except subprocess.TimeoutExpired:
+        respond("swap_active_map_respond", {
+            "result": 4,
+            "error": "LoadMap ros2 service call timed out (15s)",
+            "slot": slot,
+        })
+        return
+
+    if rc.returncode != 0:
+        respond("swap_active_map_respond", {
+            "result": 4,
+            "error": "LoadMap call failed",
+            "load_rc": rc.returncode,
+            "load_stderr": rc.stderr[-200:] if rc.stderr else None,
+            "slot": slot,
+        })
+        return
+
+    respond("swap_active_map_respond", {"result": 0, "slot": slot})
+```
+
+- [ ] **Step 3: Register the handler in `COMMANDS`**
+
+Find the `COMMANDS = {` block (search for `"sync_map":` since `sync_map` is a sibling we already register). Add a new line in the dict:
+
+```python
+    "swap_active_map": lambda p, r: handle_swap_active_map(p, r),
+```
+
+Place it alphabetically near `sync_map`. Match the existing trailing-comma style.
+
+- [ ] **Step 4: Sanity-check Python parses**
+
+Run: `python3 -c "import ast; ast.parse(open('research/extended_commands.py').read()); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add research/extended_commands.py
+git commit -m "feat(firmware): swap_active_map handler for multi-map (>3 work maps) support"
+```
+
+---
+
+## Task 2: Server endpoint + idempotency cache
+
+**Files:**
+- Modify: `server/src/routes/dashboard.ts` — add POST `/maps/:sn/active-slot` + GET helper
+- Test: `server/src/__tests__/routes/dashboardActiveSlot.test.ts` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `server/src/__tests__/routes/dashboardActiveSlot.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../mqtt/broker.js', () => ({
+  isDeviceOnline: vi.fn().mockReturnValue(true),
+  writeRawPublish: vi.fn().mockReturnValue(false),
+  getBrokerDiagnostics: vi.fn().mockReturnValue({}),
+  startMqttBroker: vi.fn(),
+  banishSn: vi.fn(),
+  unbanSn: vi.fn(),
+  listBannedSns: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock('../../dashboard/socketHandler.js', () => ({
+  getRecentLogs: vi.fn().mockReturnValue([]),
+  forwardToDashboard: vi.fn(),
+  onLogEntry: vi.fn(),
+  emitMapsChanged: vi.fn(),
+  emitDeviceOnline: vi.fn(),
+  emitDeviceOffline: vi.fn(),
+  emitTrailClear: vi.fn(),
+  emitCoveredLanes: vi.fn(),
+  setDemoModeChecker: vi.fn(),
+  setOutlineEmitter: vi.fn(),
+  initBleLogger: vi.fn(),
+  sendBleLogHistory: vi.fn(),
+  pushMqttLog: vi.fn(),
+  emitOtaEvent: vi.fn(),
+  emitPinEvent: vi.fn(),
+  emitExtendedEvent: vi.fn(),
+  emitCommandRespond: vi.fn(),
+  emitScheduleEvent: vi.fn(),
+}));
+
+vi.mock('../../mqtt/mapSync.js', async () => {
+  const actual = await vi.importActual<typeof import('../../mqtt/mapSync.js')>(
+    '../../mqtt/mapSync.js',
+  );
+  return {
+    ...actual,
+    publishToExtended: vi.fn(),
+    onExtendedResponse: vi.fn(),
+    offExtendedResponse: vi.fn(),
+    publishToDevice: vi.fn(),
+    publishRawToDevice: vi.fn(),
+  };
+});
+
+vi.mock('../../mqtt/sensorData.js', () => ({
+  deviceCache: new Map<string, Map<string, string>>(),
+  getAllDeviceSnapshots: vi.fn().mockReturnValue([]),
+  getDeviceSnapshot: vi.fn(),
+  SENSORS: [],
+  getGpsTrail: vi.fn().mockReturnValue([]),
+  clearGpsTrail: vi.fn(),
+  getLocalTrail: vi.fn().mockReturnValue([]),
+  clearLocalTrail: vi.fn(),
+  translateValue: vi.fn((_k: string, v: string) => v),
+  markPinVerified: vi.fn(),
+  getDockPose: vi.fn().mockReturnValue(null),
+}));
+
+import { dashboardRouter } from '../../routes/dashboard.js';
+import { isDeviceOnline } from '../../mqtt/broker.js';
+import * as mapSync from '../../mqtt/mapSync.js';
+import { deviceCache } from '../../mqtt/sensorData.js';
+
+const SN = 'LFIN1231000211';
+
+const app = express();
+app.use(express.json());
+app.use('/api/dashboard', dashboardRouter);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(isDeviceOnline).mockReturnValue(true);
+  vi.mocked(mapSync.offExtendedResponse).mockImplementation(() => {});
+  deviceCache.clear();
+});
+
+function ackWith(respond: Record<string, unknown>) {
+  vi.mocked(mapSync.onExtendedResponse).mockImplementation((_sn, handler) => {
+    queueMicrotask(() => handler({ swap_active_map_respond: respond } as any));
+  });
+}
+
+describe('POST /api/dashboard/maps/:sn/active-slot', () => {
+  it('publishes swap_active_map and returns 200 on result:0', async () => {
+    ackWith({ result: 0, slot: 3 });
+    const r = await request(app)
+      .post(`/api/dashboard/maps/${SN}/active-slot`)
+      .send({ slot: 3 });
+    expect(r.status).toBe(200);
+    expect(r.body).toMatchObject({ ok: true, slot: 3 });
+    expect(mapSync.publishToExtended).toHaveBeenCalledWith(
+      SN,
+      expect.objectContaining({ swap_active_map: { slot: 3 } }),
+    );
+    expect(deviceCache.get(SN)?.get('active_map_slot')).toBe('3');
+  });
+
+  it('idempotent: 2nd POST same slot is cached, no MQTT', async () => {
+    if (!deviceCache.has(SN)) deviceCache.set(SN, new Map());
+    deviceCache.get(SN)!.set('active_map_slot', '2');
+
+    const r = await request(app)
+      .post(`/api/dashboard/maps/${SN}/active-slot`)
+      .send({ slot: 2 });
+    expect(r.status).toBe(200);
+    expect(r.body).toMatchObject({ ok: true, slot: 2, cached: true });
+    expect(mapSync.publishToExtended).not.toHaveBeenCalled();
+  });
+
+  it('rejects negative slot with 400 and no MQTT', async () => {
+    const r = await request(app)
+      .post(`/api/dashboard/maps/${SN}/active-slot`)
+      .send({ slot: -1 });
+    expect(r.status).toBe(400);
+    expect(mapSync.publishToExtended).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-integer slot with 400', async () => {
+    const r = await request(app)
+      .post(`/api/dashboard/maps/${SN}/active-slot`)
+      .send({ slot: 'two' });
+    expect(r.status).toBe(400);
+    expect(mapSync.publishToExtended).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when mower offline', async () => {
+    vi.mocked(isDeviceOnline).mockReturnValue(false);
+    const r = await request(app)
+      .post(`/api/dashboard/maps/${SN}/active-slot`)
+      .send({ slot: 0 });
+    expect(r.status).toBe(404);
+  });
+
+  it('translates mower result:2 (slot not mapped) to 400 with helpful error', async () => {
+    ackWith({ result: 2, error: 'map5 not mapped on this mower (yaml/pgm missing)', slot: 5 });
+    const r = await request(app)
+      .post(`/api/dashboard/maps/${SN}/active-slot`)
+      .send({ slot: 5 });
+    expect(r.status).toBe(400);
+    expect(r.body.ok).toBe(false);
+    expect(String(r.body.error)).toContain('map first via the app');
+    expect(deviceCache.get(SN)?.has('active_map_slot')).toBe(false);
+  });
+
+  it('translates mower result:3 (coverage active) to 409', async () => {
+    ackWith({ result: 3, error: 'coverage active, swap refused' });
+    const r = await request(app)
+      .post(`/api/dashboard/maps/${SN}/active-slot`)
+      .send({ slot: 1 });
+    expect(r.status).toBe(409);
+    expect(String(r.body.error)).toContain('stop mowing first');
+  });
+
+  it('translates mower result:4 (LoadMap fail) to 500', async () => {
+    ackWith({ result: 4, error: 'LoadMap call failed', load_rc: 1 });
+    const r = await request(app)
+      .post(`/api/dashboard/maps/${SN}/active-slot`)
+      .send({ slot: 1 });
+    expect(r.status).toBe(500);
+  });
+});
+
+describe('GET /api/dashboard/maps/:sn/active-slot', () => {
+  it('returns the cached slot or null', async () => {
+    let r = await request(app).get(`/api/dashboard/maps/${SN}/active-slot`);
+    expect(r.status).toBe(200);
+    expect(r.body).toEqual({ slot: null });
+
+    if (!deviceCache.has(SN)) deviceCache.set(SN, new Map());
+    deviceCache.get(SN)!.set('active_map_slot', '4');
+    r = await request(app).get(`/api/dashboard/maps/${SN}/active-slot`);
+    expect(r.body).toEqual({ slot: 4 });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, expect FAIL**
+
+Run: `cd server && npx vitest run src/__tests__/routes/dashboardActiveSlot.test.ts`
+Expected: all 9 cases FAIL — endpoints not registered.
+
+- [ ] **Step 3: Add the endpoints**
+
+In `server/src/routes/dashboard.ts`, append (locate the existing `dashboardRouter.get('/rain-sessions/:sn', ...)` block and insert these new routes immediately after it for visibility):
+
+```ts
+// ─────────────────────────────────────────────────────────────────────────────
+// Active map slot — multi-map support (>3 work maps).
+// Spec: docs/superpowers/specs/2026-05-04-multi-map-swap-active-slot.md
+//
+// POST /api/dashboard/maps/:sn/active-slot { slot: number }
+//   Tells the mower to copy mapN.{yaml,pgm,png} over the active map.* slot
+//   and reload the nav stack. Idempotent — second call with the same slot
+//   is satisfied from the deviceCache.
+//
+// GET /api/dashboard/maps/:sn/active-slot
+//   Returns the cached active slot (or null when never set).
+// ─────────────────────────────────────────────────────────────────────────────
+
+dashboardRouter.post('/maps/:sn/active-slot', async (req: Request, res: Response) => {
+  const { sn } = req.params;
+  const slotRaw = (req.body as { slot?: unknown }).slot;
+  if (typeof slotRaw !== 'number' || !Number.isInteger(slotRaw) || slotRaw < 0) {
+    res.status(400).json({ ok: false, error: 'slot must be a non-negative integer' });
+    return;
+  }
+  const slot = slotRaw;
+
+  if (!isDeviceOnline(sn)) {
+    res.status(404).json({ ok: false, error: 'Device is offline' });
+    return;
+  }
+
+  // Idempotency: if cache says we're already on this slot, skip MQTT.
+  const cached = deviceCache.get(sn)?.get('active_map_slot');
+  if (cached === String(slot)) {
+    res.json({ ok: true, slot, cached: true });
+    return;
+  }
+
+  const { publishToExtended, onExtendedResponse, offExtendedResponse } =
+    await import('../mqtt/mapSync.js');
+
+  type Result = { ok: boolean; respond?: Record<string, unknown>; timeout?: boolean };
+  const result = await new Promise<Result>(resolve => {
+    let settled = false;
+    const handler = (data: Record<string, unknown>) => {
+      const r = data.swap_active_map_respond as Record<string, unknown> | undefined;
+      if (!r || settled) return;
+      settled = true;
+      offExtendedResponse(sn, handler);
+      resolve({ ok: r.result === 0, respond: r });
+    };
+    onExtendedResponse(sn, handler);
+    publishToExtended(sn, { swap_active_map: { slot } });
+    setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      offExtendedResponse(sn, handler);
+      resolve({ ok: false, timeout: true });
+    }, 15000);
+  });
+
+  if (result.timeout) {
+    res.status(504).json({ ok: false, error: 'mower did not ack within 15s', slot });
+    return;
+  }
+  if (result.ok) {
+    if (!deviceCache.has(sn)) deviceCache.set(sn, new Map());
+    deviceCache.get(sn)!.set('active_map_slot', String(slot));
+    forwardToDashboard(sn, new Map([['active_map_slot', String(slot)]]));
+    res.json({ ok: true, slot, respond: result.respond });
+    return;
+  }
+
+  // Translate mower error codes to HTTP statuses.
+  const code = (result.respond?.result as number | undefined) ?? -1;
+  const mowerErr = String(result.respond?.error ?? 'swap failed');
+  if (code === 2) {
+    res.status(400).json({
+      ok: false,
+      error: `${mowerErr} — map first via the app`,
+      respond: result.respond,
+    });
+  } else if (code === 3) {
+    res.status(409).json({
+      ok: false,
+      error: `${mowerErr} — stop mowing first`,
+      respond: result.respond,
+    });
+  } else if (code === 4) {
+    res.status(500).json({ ok: false, error: mowerErr, respond: result.respond });
+  } else {
+    res.status(400).json({ ok: false, error: mowerErr, respond: result.respond });
+  }
+});
+
+dashboardRouter.get('/maps/:sn/active-slot', (req: Request, res: Response) => {
+  const cached = deviceCache.get(req.params.sn)?.get('active_map_slot');
+  res.json({ slot: cached != null ? parseInt(cached, 10) : null });
+});
+```
+
+- [ ] **Step 4: Run tests to confirm pass**
+
+Run: `cd server && npx vitest run src/__tests__/routes/dashboardActiveSlot.test.ts`
+Expected: 9/9 PASS.
+
+- [ ] **Step 5: Run full server suite — no regressions**
+
+Run: `cd server && npx vitest run`
+Expected: all tests pass, totals approximately 295/295 (eight added).
+
+- [ ] **Step 6: TS + lint checks**
+
+Run: `cd server && npx tsc --noEmit && npx eslint src/routes/dashboard.ts`
+Expected: no output (clean).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/routes/dashboard.ts server/src/__tests__/routes/dashboardActiveSlot.test.ts
+git commit -m "feat(server): /maps/:sn/active-slot endpoint with idempotent swap_active_map RPC"
+```
+
+---
+
+## Task 3: ScheduleRunner pre-swap
+
+**Files:**
+- Modify: `server/src/services/scheduleRunner.ts` — call swap before `startMowing` in `triggerSchedule`
+
+- [ ] **Step 1: Inspect the current trigger code**
+
+Run: `grep -n "function triggerSchedule\|startMowing(" server/src/services/scheduleRunner.ts`
+
+Expected: shows `triggerSchedule(row: ScheduleRow)` and a call to `startMowing({sn, ...})` inside it. The swap call must go just BEFORE that `startMowing` invocation.
+
+- [ ] **Step 2: Add a helper that resolves `slot` from the schedule's mapId**
+
+Add this near the top of `server/src/services/scheduleRunner.ts` (after the existing imports — keep imports ordered):
+
+```ts
+/** Resolve the firmware slot index from the schedule's stored mapId.
+ *  Reads canonical_name on the maps row and parses the trailing
+ *  digits ("map7_work" -> 7). Returns null when the row is missing or
+ *  the canonical_name doesn't match. */
+function resolveSlotForSchedule(row: ScheduleRow): number | null {
+  if (!row.map_id) return null;
+  const mapRow = mapRepo.findById(row.map_id);
+  const canonical = mapRow?.canonical_name ?? '';
+  const m = canonical.match(/^map(\d+)/);
+  return m ? parseInt(m[1], 10) : null;
+}
+```
+
+- [ ] **Step 3: Insert the swap call inside `triggerSchedule`**
+
+Modify `triggerSchedule` so the very first thing it does (before computing `effectiveDirection`) is:
+
+```ts
+function triggerSchedule(row: ScheduleRow) {
+  // Multi-map support: ensure the mower has the right slot loaded into
+  // its active map.yaml before kicking off the mow. Skips when the
+  // schedule is bound to a slot we can't resolve (legacy rows). Spec:
+  // docs/superpowers/specs/2026-05-04-multi-map-swap-active-slot.md
+  const slot = resolveSlotForSchedule(row);
+  if (slot != null) {
+    void (async () => {
+      try {
+        const { publishToExtended, onExtendedResponse, offExtendedResponse } =
+          await import('../mqtt/mapSync.js');
+        await new Promise<void>(resolve => {
+          let settled = false;
+          const handler = (data: Record<string, unknown>) => {
+            if (!data.swap_active_map_respond || settled) return;
+            settled = true;
+            offExtendedResponse(row.mower_sn, handler);
+            resolve();
+          };
+          onExtendedResponse(row.mower_sn, handler);
+          publishToExtended(row.mower_sn, { swap_active_map: { slot } });
+          setTimeout(() => {
+            if (settled) return;
+            settled = true;
+            offExtendedResponse(row.mower_sn, handler);
+            resolve();  // never block the mow on swap timeout
+          }, 15000);
+        });
+      } catch (err) {
+        console.error(`[ScheduleRunner] swap_active_map failed for ${row.mower_sn} slot=${slot}:`, err);
+      }
+      runStartMowing(row);
+    })();
+    return;
+  }
+  runStartMowing(row);
+}
+
+function runStartMowing(row: ScheduleRow) {
+  // Bereken effectieve richting (met alternerende rotatie)
+  let effectiveDirection = row.path_direction;
+  if (row.alternate_direction === 1) {
+    const count = messageRepo.countWorkRecordsBySchedule(row.schedule_id);
+    effectiveDirection = (row.path_direction + count * (row.alternate_step ?? 90)) % 360;
+  }
+
+  // Start maaien via centrale mowingService
+  const result = startMowing({
+    sn: row.mower_sn,
+    cuttingHeight: row.cutting_height ?? 5,
+    pathDirection: effectiveDirection,
+    area: 1,
+  });
+  console.log(`[ScheduleRunner] ${row.schedule_id}: ${result.ok ? 'started' : 'FAILED: ' + result.error} (height=${row.cutting_height}, dir=${effectiveDirection})`);
+
+  // Update last_triggered_at
+  scheduleRepo.updateLastTriggered(row.schedule_id);
+
+  emitScheduleEvent('weather:started', {
+    scheduleId: row.schedule_id,
+    mowerSn: row.mower_sn,
+    effectiveDirection,
+  });
+}
+```
+
+> **Note:** the existing body of `triggerSchedule` is moved verbatim into `runStartMowing`. Make sure to delete the old body — the `function triggerSchedule(row)` block now ONLY does the swap-then-`runStartMowing` orchestration above.
+
+- [ ] **Step 4: Verify TS clean**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: no output.
+
+- [ ] **Step 5: Run full server suite**
+
+Run: `cd server && npx vitest run`
+Expected: all tests pass (no scheduleRunner test exists for swap path; existing UTC-guard test must still pass).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/services/scheduleRunner.ts
+git commit -m "feat(server): scheduleRunner pre-swaps active map slot before triggerSchedule"
+```
+
+---
+
+## Task 4: App API client method
+
+**Files:**
+- Modify: `app/src/services/api.ts` — add `setActiveMapSlot` + `getActiveMapSlot`
+
+- [ ] **Step 1: Locate insertion point**
+
+Run: `grep -n "async setRainIgnoreSession\b" app/src/services/api.ts`
+
+Expected: returns the line number where `setRainIgnoreSession` is defined (a recently-added similar method). Add the new methods right after that one.
+
+- [ ] **Step 2: Add the methods**
+
+Insert immediately after the closing `}` of `setRainIgnoreSession`:
+
+```ts
+  async setActiveMapSlot(sn: string, slot: number): Promise<{ ok: boolean; slot: number; cached?: boolean; error?: string }> {
+    return this.request<{ ok: boolean; slot: number; cached?: boolean; error?: string }>(
+      'POST',
+      `/api/dashboard/maps/${encodeURIComponent(sn)}/active-slot`,
+      { body: { slot } },
+    );
+  }
+
+  async getActiveMapSlot(sn: string): Promise<{ slot: number | null }> {
+    return this.request<{ slot: number | null }>(
+      'GET',
+      `/api/dashboard/maps/${encodeURIComponent(sn)}/active-slot`,
+    );
+  }
+```
+
+- [ ] **Step 3: TS check**
+
+Run: `cd app && npx tsc --noEmit`
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/services/api.ts
+git commit -m "feat(app): api.setActiveMapSlot + getActiveMapSlot client methods"
+```
+
+---
+
+## Task 5: StartMowSheet pre-swap
+
+**Files:**
+- Modify: `app/src/components/StartMowSheet.tsx` — call `setActiveMapSlot` before `start_navigation`
+
+- [ ] **Step 1: Find the canonical-slot derivation already in place**
+
+Run: `grep -n "canonicalIdx\|setActiveMapSlot\|orderedMapIds\[0\]" app/src/components/StartMowSheet.tsx`
+
+Expected: shows the `canonicalIdx` computation block you added earlier (around line 304) and the `start_navigation` dispatch around line 311. The new swap call goes between them.
+
+- [ ] **Step 2: Insert swap call before `start_navigation`**
+
+Edit the single-map dispatch path. Replace this existing block (verify exact lines via grep first — they may have moved):
+
+```ts
+      // Single-map path (legacy, identical to pre-multi-select behaviour).
+      // Issue #14 / #18: derive the firmware `area` enum from the canonical
+      // slot identifier (map0/map1/map2) so the user's selection lines up
+      // with the mower's internal index. Sorting by updated_at + using array
+      // index produced "select front, mow trampo" because the alphabetical
+      // app order didn't match the firmware's creation order.
+      const selectedMap = maps.find(m => m.mapId === orderedMapIds[0]) ?? maps[0];
+      const canonicalIdx = (() => {
+        const m = (selectedMap?.canonicalName ?? '').match(/^map(\d+)/);
+        return m ? parseInt(m[1], 10) : null;
+      })();
+      const fallbackIdx = maps.findIndex(m => m.mapId === orderedMapIds[0]);
+      const mapIdx = canonicalIdx ?? (fallbackIdx >= 0 ? fallbackIdx : 0);
+      // Firmware `area` enum: map0=1, map1=10, map2=200. Confirmed in
+      // docs/reference/MOWING-FLOW.md. Three slots only (firmware limit).
+      const areaParam = mapIdx === 0 ? 1 : mapIdx === 1 ? 10 : 200;
+```
+
+with:
+
+```ts
+      // Single-map path. Use canonicalName for the firmware slot index so
+      // we always dispatch the map the user actually picked (not the array
+      // position). Issue #14 / #18.
+      const selectedMap = maps.find(m => m.mapId === orderedMapIds[0]) ?? maps[0];
+      const canonicalIdx = (() => {
+        const m = (selectedMap?.canonicalName ?? '').match(/^map(\d+)/);
+        return m ? parseInt(m[1], 10) : null;
+      })();
+      const fallbackIdx = maps.findIndex(m => m.mapId === orderedMapIds[0]);
+      const mapIdx = canonicalIdx ?? (fallbackIdx >= 0 ? fallbackIdx : 0);
+
+      // Multi-map support (spec 2026-05-04): ask the server to swap the
+      // mower's active map.yaml to the selected slot before dispatching
+      // start_navigation. After a successful swap, area is irrelevant —
+      // the loaded map.yaml IS the requested map. We send area=0 to avoid
+      // the legacy 1/10/200 enum.
+      try {
+        await api.setActiveMapSlot(sn, mapIdx);
+      } catch (e) {
+        console.log('[StartMow] setActiveMapSlot failed:', e);
+        // surface to user so they don't think the mow started silently
+        const msg = e instanceof Error ? e.message : 'swap failed';
+        Alert.alert(t('startMowFailed') || 'Could not start', msg);
+        return;
+      }
+      const areaParam = 0;
+```
+
+- [ ] **Step 3: Same change for the multi-map enqueue path**
+
+Find the `if (orderedMapIds.length > 1) {` block above it (search around line 286). Inside that block, BEFORE `await enqueue({...})`, add a swap call for the FIRST map only — the queue handles subsequent swaps in Task 6:
+
+```ts
+      if (orderedMapIds.length > 1) {
+        // Multi-map: hand off to the queue. Pre-swap the first map so the
+        // initial start_navigation lands on the right slot. The queue
+        // performs additional swaps before each subsequent dispatch.
+        const firstMap = maps.find(m => m.mapId === orderedMapIds[0]) ?? maps[0];
+        const firstSlot = (() => {
+          const m = (firstMap?.canonicalName ?? '').match(/^map(\d+)/);
+          return m ? parseInt(m[1], 10) : 0;
+        })();
+        try {
+          await api.setActiveMapSlot(sn, firstSlot);
+        } catch (e) {
+          console.log('[StartMow] setActiveMapSlot failed (queue head):', e);
+          const msg = e instanceof Error ? e.message : 'swap failed';
+          Alert.alert(t('startMowFailed') || 'Could not start', msg);
+          return;
+        }
+        await api.clearTrail(sn).catch(() => {});
+        await enqueue({
+          sn,
+          mapIds: orderedMapIds,
+          cuttingHeight,
+          pathDirection,
+        });
+        console.log(`[StartMow] enqueued ${orderedMapIds.length} maps:`, orderedMapIds.join(','));
+        onStarted({ cuttingHeight: wireHeight, pathDirection });
+        onClose();
+        return;
+      }
+```
+
+- [ ] **Step 4: TS check**
+
+Run: `cd app && npx tsc --noEmit`
+Expected: no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/components/StartMowSheet.tsx
+git commit -m "feat(app): StartMowSheet pre-swaps active map slot before start_navigation"
+```
+
+---
+
+## Task 6: MowQueueContext pre-swap per dispatch
+
+**Files:**
+- Modify: `app/src/context/MowQueueContext.tsx` — call swap before each per-map start
+
+- [ ] **Step 1: Locate the dispatch site**
+
+Run: `grep -n "areaParamFromIdx\|sendCommand.*start_navigation\|head\.mapIdx" app/src/context/MowQueueContext.tsx`
+
+Expected: shows the place in `MowQueueProvider` where each queued map dispatches `start_navigation`. The swap call goes immediately before that `sendCommand`.
+
+- [ ] **Step 2: Insert swap call**
+
+Find the dispatch block (around the line `console.log('[MowQueue] dispatch ${head.mapName} ...')`). Replace the dispatch block:
+
+```ts
+      console.log(`[MowQueue] dispatch ${head.mapName} (idx=${head.mapIdx}) cutterhigh=${wireHeight}`);
+      const navResult = await api.sendCommand(state.sn, {
+        start_navigation: {
+          mapName: 'test',
+          area: areaParamFromIdx(head.mapIdx),
+          cutterhigh: wireHeight,
+          cmd_num: Date.now() % 100000,
+        },
+      });
+```
+
+with:
+
+```ts
+      console.log(`[MowQueue] dispatch ${head.mapName} (idx=${head.mapIdx}) cutterhigh=${wireHeight}`);
+      // Multi-map support (spec 2026-05-04): swap the active map slot
+      // before each dispatch so the queue can mow ANY canonical slot,
+      // not just map0/1/2. Treat swap failure as a fatal queue error
+      // — better to abort cleanly than mow the wrong polygon.
+      try {
+        await api.setActiveMapSlot(state.sn, head.mapIdx);
+      } catch (err) {
+        console.warn(`[MowQueue] setActiveMapSlot failed for slot=${head.mapIdx}:`, err);
+        return;
+      }
+      const navResult = await api.sendCommand(state.sn, {
+        start_navigation: {
+          mapName: 'test',
+          area: 0,  // map.yaml swap above makes the legacy area enum irrelevant
+          cutterhigh: wireHeight,
+          cmd_num: Date.now() % 100000,
+        },
+      });
+```
+
+- [ ] **Step 3: TS check**
+
+Run: `cd app && npx tsc --noEmit`
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/context/MowQueueContext.tsx
+git commit -m "feat(app): MowQueueContext pre-swaps active map slot before each per-map dispatch"
+```
+
+---
+
+## Task 7: Dashboard MowerControls pre-swap
+
+**Files:**
+- Modify: `dashboard/src/components/dashboard/MowerControls.tsx`
+
+- [ ] **Step 1: Locate the start_navigation dispatch**
+
+Run: `grep -n "start_navigation\|workMaps\.indexOf\|areaParam" dashboard/src/components/dashboard/MowerControls.tsx`
+
+Expected: shows the existing `mapIdx` computation and the `sendCommand(sn, { start_navigation: ... })` block (around line 290).
+
+- [ ] **Step 2: Replace the dispatch**
+
+Replace this block:
+
+```ts
+        const cmdNum = nextCmdNum();
+        const navPayload: Record<string, unknown> = {
+          mapName: resolvedMapName,
+          cutterhigh: wireHeight,
+          area: areaParam,
+          cmd_num: cmdNum,
+        };
+        const navResult = await sendCommand(sn, { start_navigation: navPayload });
+
+        if (!navResult.ok) {
+          // Fallback: old firmware protocol (matches app StartMowSheet.tsx line 317)
+          await sendCommand(sn, {
+            start_run: { mapName: null, area: areaParam, cutterhigh: wireHeight },
+          });
+        }
+```
+
+with:
+
+```ts
+        // Multi-map support (spec 2026-05-04): swap the active map slot
+        // before dispatching so the dashboard can mow any work map, not
+        // only the first 3 covered by the legacy area enum. Translate
+        // mapIdx → slot via the same parse rule the app uses.
+        try {
+          await fetch(`${apiBase}/api/dashboard/maps/${encodeURIComponent(sn)}/active-slot`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ slot: mapIdx }),
+          });
+        } catch (err) {
+          toast(`✗ ${t('controls.startMowing')}: swap failed (${String(err)})`, 'error');
+          setBusy(false);
+          return;
+        }
+
+        const cmdNum = nextCmdNum();
+        const navPayload: Record<string, unknown> = {
+          mapName: resolvedMapName,
+          cutterhigh: wireHeight,
+          area: 0,  // post-swap, map.yaml IS the requested map
+          cmd_num: cmdNum,
+        };
+        const navResult = await sendCommand(sn, { start_navigation: navPayload });
+
+        if (!navResult.ok) {
+          // Fallback: old firmware protocol (matches app StartMowSheet.tsx line 317)
+          await sendCommand(sn, {
+            start_run: { mapName: null, area: 0, cutterhigh: wireHeight },
+          });
+        }
+```
+
+- [ ] **Step 3: Resolve `apiBase`**
+
+If `apiBase` isn't already imported in scope, add it. Run: `grep -n "import.*api\b\|API_BASE\|getApiBase" dashboard/src/components/dashboard/MowerControls.tsx` to find the existing convention and use it. If the convention is to call a helper like `apiUrl(...)`, use that instead of building the URL inline.
+
+- [ ] **Step 4: TS check**
+
+Run: `cd dashboard && npx tsc --noEmit`
+Expected: no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/src/components/dashboard/MowerControls.tsx
+git commit -m "feat(dashboard): MowerControls pre-swaps active map slot before start"
+```
+
+---
+
+## Task 8: Live deploy + acceptance test
+
+**Files:**
+- No new files — runbook + verification only.
+
+- [ ] **Step 1: SCP the updated extended_commands.py to the test mower**
+
+```bash
+sshpass -p novabot scp \
+  research/extended_commands.py \
+  root@192.168.0.100:/root/novabot/scripts/extended_commands.py
+```
+
+- [ ] **Step 2: Restart the daemon**
+
+```bash
+sshpass -p novabot ssh root@192.168.0.100 \
+  'pkill -9 -f "extended_commands.py"; sleep 2; \
+   nohup python3 /root/novabot/scripts/extended_commands.py >> /tmp/extcmd_relaunch.log 2>&1 < /dev/null & \
+   sleep 3; pgrep -af extended_commands'
+```
+
+Expected: a new PID appears.
+
+- [ ] **Step 3: Build + push the server image**
+
+Skip if not deploying to NAS — run from local dev container instead. To deploy:
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 \
+  --builder multiplatform-builder \
+  -t rvbcrs/opennova:latest --push --no-cache .
+sshpass -p 'M@rleen146' ssh rvbcrs@192.168.0.247 \
+  'echo "M@rleen146" | sudo -S docker pull rvbcrs/opennova:latest && \
+   echo "M@rleen146" | sudo -S docker restart opennova'
+```
+
+- [ ] **Step 4: Verify the test mower has at least one slot beyond map0**
+
+```bash
+sshpass -p novabot ssh root@192.168.0.100 \
+  'ls /userdata/lfi/maps/home0/map*.yaml /userdata/lfi/maps/home0/map*.pgm'
+```
+
+Expected: at minimum `map0.yaml/.pgm` and `map1.yaml/.pgm`. If only map0 exists, the acceptance test cannot proceed — first map a 2nd area through the Novabot stock app on the same mower (it caps at 3 in UI but our test only needs 2 slots). LOG which slots exist in the runbook before continuing.
+
+- [ ] **Step 5: Trigger a swap from the server and verify**
+
+Hit the new endpoint via curl (use the server's JWT — or temporarily disable auth for the test):
+
+```bash
+curl -sX POST http://192.168.0.247:8080/api/dashboard/maps/LFIN1231000211/active-slot \
+  -H 'Content-Type: application/json' \
+  -d '{"slot": 1}'
+```
+
+Expected JSON: `{"ok":true,"slot":1,"respond":{"result":0,"slot":1}}`.
+
+Then confirm on the mower:
+
+```bash
+sshpass -p novabot ssh root@192.168.0.100 \
+  'cmp /userdata/lfi/maps/home0/map.yaml /userdata/lfi/maps/home0/map1.yaml && \
+   tail -10 /tmp/extcmd_relaunch.log | grep swap_active_map'
+```
+
+Expected: `cmp` returns 0 (files identical) and the log shows the handler fired.
+
+- [ ] **Step 6: Start a real mow**
+
+From the OpenNova app, select the 2nd work map and tap Start. Expected: mower drives the 2nd map's polygon (not map0). Verify by watching `cov_map_path` in the dashboard or by physical observation.
+
+- [ ] **Step 7: Document the result**
+
+Append a short note to `docs/runbooks/charger-anchor-restore-runbook.md` (or create a new runbook `docs/runbooks/multi-map-mowing.md`) describing the procedure operators use to confirm the swap is healthy. Keep it minimal — link to the spec for details.
+
+```bash
+git add docs/runbooks/
+git commit -m "docs: runbook note for multi-map active-slot swap"
+```
+
+- [ ] **Step 8: Push the branch and open a PR**
+
+```bash
+git push -u origin feat/multi-map-swap
+gh pr create --title "feat: support >3 work maps via active-slot swap" --body "$(cat <<'EOF'
+## Summary
+- New `swap_active_map` extended-command handler on the mower copies `mapN.{yaml,pgm,png}` over the active slot and reloads `map_server`.
+- New server endpoint `POST /api/dashboard/maps/:sn/active-slot` orchestrates the swap with idempotency caching and proper error translation.
+- App + dashboard + scheduleRunner pre-swap the active slot before every `start_navigation`, so any work map (canonical `mapN`) can be mowed regardless of the legacy 1/10/200 area enum.
+
+Spec: `docs/superpowers/specs/2026-05-04-multi-map-swap-active-slot.md`
+
+## Test plan
+- [ ] `cd server && npx vitest run` passes (incl. 9 new active-slot tests)
+- [ ] `cd app && npx tsc --noEmit` clean
+- [ ] `cd dashboard && npx tsc --noEmit` clean
+- [ ] Acceptance test on LFIN1231000211 — swap to slot 1 reflected in `cmp map.yaml map1.yaml` returning 0
+- [ ] Real mow on slot 1 from the app drives the right polygon
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes
+
+- Spec section 1 (Goal) covered by Task 1 (handler) + Task 2 (endpoint).
+- Spec section 2 (mower handler result codes) — Task 1 implements, Task 2 tests cover translation.
+- Spec section 3 (server orchestration + idempotency) — Task 2.
+- Spec section 4 (app side) — Tasks 4, 5, 6.
+- Spec section 5 (scheduleRunner) — Task 3.
+- Spec section 6 (dashboard) — Task 7.
+- Spec section 7 (acceptance / failure modes) — Task 8.
+- Telemetry forwarding (`forwardToDashboard(sn, {active_map_slot})`) — Task 2 step 3.
+- TODO from spec ("confirm firmware accepts mapName 'mapN' for N≥3") — out of plan scope by design; this plan implements the SWAP path which works once the slot files exist on disk. A separate plan must extend the BLE mapping screen.

--- a/docs/superpowers/specs/2026-05-04-multi-map-swap-active-slot.md
+++ b/docs/superpowers/specs/2026-05-04-multi-map-swap-active-slot.md
@@ -1,0 +1,253 @@
+# Multi-Map Support via Active-Slot Swap
+
+**Date:** 2026-05-04
+**Status:** Spec — pending implementation plan
+
+## Problem
+
+The mower's stock firmware enum for `start_navigation.area` only supports
+three magic values: `1` (map0), `10` (map1), `200` (map2). Any work map
+beyond the third slot is unreachable from the app/dashboard — selecting
+"map3" or higher silently dispatches the wrong polygon (or does nothing
+at all).
+
+This is not a true firmware limit. The actual mowing is driven by
+whatever `home0/map.yaml` + `home0/map.pgm` are loaded into the nav
+stack at the moment `StartCoverageTask` fires. The firmware writes
+per-slot files (`mapN.yaml`, `mapN.pgm`, `mapN.png`) during BLE
+mapping but only ever loads `map.yaml` itself. The 1/10/200 enum is
+mostly cosmetic — it sets `request_map_ids` in telemetry but does not
+gate which polygon gets mowed.
+
+The `area` enum is therefore a stock-app convention, not a firmware
+constraint. Once we control the swap-to-`map.yaml` step on the mower
+we can support an arbitrary number of work maps without touching
+`mqtt_node`, `robot_decision`, or `coverage_planner`.
+
+## Goal
+
+Add a `swap_active_map` extended-command handler on the mower plus a
+matching server endpoint that the app/dashboard call before any
+`start_navigation` whose target slot ≠ the currently-loaded slot. The
+handler copies `mapN.{yaml,pgm,png}` over `map.{yaml,pgm,png}` and
+issues a `LoadMap` ROS service call so the nav stack picks up the new
+grid. After the swap, `start_navigation` runs with `area: 0` and the
+mower mowes whatever `map.yaml` now points at.
+
+## Non-Goals
+
+- **No synthetic yaml/pgm generation.** A slot is "swappable" only when
+  the mower physically mapped it (so `mapN.yaml` + `mapN.pgm` exist on
+  disk). Polygon-only uploads from the app — where the user pushes a
+  CSV without ever having walked the perimeter on the mower — are
+  out-of-scope and continue to fail with "map N never physically
+  mapped on this mower". A separate flow can add synthetic-grid
+  fallback later.
+- **No firmware patches.** No edits to the closed `mqtt_node`,
+  `robot_decision`, or `coverage_planner` binaries. The swap operates
+  purely on disk + a public ROS service (`/map_server/load_map`).
+- **No `area` enum extension.** We deliberately stop relying on the
+  `area` enum to identify the slot — the active slot is server-side
+  state and reflected back in telemetry via a new `active_map_slot`
+  cache key.
+- **No mid-mow swaps.** The mower handler refuses a swap when coverage
+  is active. The user must stop the running task first.
+
+## Architecture
+
+```
+app / dashboard
+  │
+  │ POST /api/dashboard/maps/<sn>/active-slot { slot: N }
+  ▼
+server
+  │  ├─ idempotency check: deviceCache[sn].active_map_slot === N → 200 cached
+  │  └─ publishToExtended(sn, { swap_active_map: { slot: N } })
+  │       │   await swap_active_map_respond (15s timeout)
+  │       ▼
+  │  mower extended_commands.py
+  │    │  guards:
+  │    │    slot < 0                 → result:1
+  │    │    mapN.yaml or .pgm absent → result:2
+  │    │    coverage active          → result:3
+  │    │  steps:
+  │    │    cp mapN.yaml → map.yaml.tmp; rename(map.yaml.tmp, map.yaml)
+  │    │    cp mapN.pgm  → map.pgm.tmp;  rename(map.pgm.tmp,  map.pgm)
+  │    │    cp mapN.png  → map.png.tmp;  rename(map.png.tmp,  map.png)
+  │    │    ros2 service call /map_server/load_map nav2_msgs/srv/LoadMap
+  │    │      "{map_url: '/userdata/lfi/maps/home0/map.yaml'}"
+  │    │  LoadMap rc != 0           → result:4
+  │    └─ respond { result: 0, slot: N }
+  │
+  ▼ on success:
+  deviceCache[sn].active_map_slot = String(N)
+  forwardToDashboard(sn, { active_map_slot: N })
+  res.json({ ok: true, slot: N })
+
+app / dashboard
+  │
+  │ POST /api/dashboard/command/<sn>
+  │   body { command: { start_navigation: { area: 0, cutterhigh, cmd_num } } }
+  ▼
+mqtt → mower → mowes whatever map.yaml currently points at
+```
+
+### Components
+
+**Mower handler — `research/extended_commands.py`**
+
+- New `handle_swap_active_map(params, respond)` registered in `COMMANDS`
+  dict.
+- Inputs: `slot` (int, required, ≥0).
+- Reads `/userdata/lfi/maps/home0/map<slot>.{yaml,pgm,png}` and
+  rewrites `/userdata/lfi/maps/home0/map.{yaml,pgm,png}` via
+  `shutil.copy2 → os.replace` for atomicity.
+- Calls `/map_server/load_map` via the existing ROS launch env (same
+  pattern as `_restart_novabot_mapping`).
+- Returns `swap_active_map_respond` with one of these results:
+
+| `result` | meaning |
+|----------|---------|
+| 0 | success — `slot` field echoes the active slot |
+| 1 | bad request (negative or missing slot) or copy failure |
+| 2 | requested slot was never mapped on this mower (file missing) |
+| 3 | coverage is active — refuse to swap mid-task |
+| 4 | files copied but `LoadMap` ROS call failed |
+
+The handler is independent of `mqtt_node` (uses `extended_commands.py`
+own MQTT client). It does NOT touch `auto_recharge_server` or
+`charging_station.yaml`.
+
+**Server endpoint — `server/src/routes/dashboard.ts`**
+
+`POST /api/dashboard/maps/:sn/active-slot` body `{ slot: number }`:
+
+- Validation: integer, ≥0, mower online, mower not in demo mode.
+- Idempotency: if `deviceCache[sn].active_map_slot === String(slot)`
+  reply `{ ok: true, slot, cached: true }` immediately.
+- Otherwise publish `{swap_active_map: {slot}}` via
+  `publishToExtended` and await `swap_active_map_respond` with a
+  15-second timeout (copy + LoadMap takes 5–10 s in practice).
+- On `result === 0`: cache the slot, broadcast it through
+  `forwardToDashboard` so the active map UI updates live.
+- Translate mower error codes:
+
+| mower `result` | HTTP status | body |
+|----------------|-------------|------|
+| 0 | 200 | `{ok:true, slot}` |
+| 1 / copy fail | 400 | `{ok:false, error}` |
+| 2 / not mapped | 400 | `{ok:false, error: 'map N never physically mapped on this mower — map it from the app first'}` |
+| 3 / coverage active | 409 | `{ok:false, error: 'coverage active — stop mowing first'}` |
+| 4 / LoadMap failed | 500 | `{ok:false, error, respond}` |
+| timeout | 504 | `{ok:false, error: 'mower did not ack within 15s'}` |
+
+**App side — `StartMowSheet.tsx`, `MowQueueContext.tsx`, schedule runner**
+
+Before any `start_navigation`/`start_run` dispatch:
+
+1. Compute `slot = parseInt(canonicalName.match(/^map(\d+)/)?.[1] ?? '')`.
+2. If `slot != null` AND `slot !== currentActiveSlot` (read from
+   `mower.sensors.active_map_slot`), call
+   `api.setActiveMapSlot(sn, slot)`. Treat 200/cached as success.
+3. On 4xx/5xx surface a Toast / inline error and abort the mow.
+4. Send the start command with `area: 0` (the enum is now meaningless
+   because the loaded `map.yaml` IS the requested map).
+
+`MowQueueContext` performs the swap before each per-map dispatch in
+the queue.
+
+`server/src/services/scheduleRunner.ts`'s `triggerSchedule` calls the
+swap server-side via the same code path before invoking `startMowing`.
+
+### Telemetry
+
+A new synthetic sensor key `active_map_slot` is written to
+`deviceCache` on every successful swap. It feeds:
+
+- `report_state_robot` snapshots forwarded over Socket.io for the
+  dashboard's "active map" badge.
+- App `MowerState` so HomeScreen can display the active polygon
+  unambiguously instead of decoding the firmware's
+  `current_map_ids` enum.
+
+The firmware's `current_map_ids` field stays untouched (still
+reflects whatever the mower itself reports — typically 1 / 10 / 100
+post-swap).
+
+## Tests
+
+**Server** — `server/src/__tests__/routes/dashboardActiveSlot.test.ts`:
+
+- POST happy path → 200 + `cache.active_map_slot === '3'` after mock
+  ack with `result: 0`.
+- Idempotent retry → 200 with `cached:true`, no second `publishToExtended`.
+- `slot: -1` / missing → 400 before any MQTT.
+- Mower offline → 404.
+- Mower returns `result: 2` → 400 with the human-readable error.
+- Mower returns `result: 3` → 409.
+- 15-second timeout → 504.
+
+**Mower handler** — covered by acceptance test (Python ROS env makes
+unit-testing `subprocess.run('ros2 service call …')` brittle and
+low-value).
+
+**Acceptance** — live mower runbook:
+
+1. Map a 2nd work area via the Novabot app on a mower that already
+   has map0.
+2. Verify `/userdata/lfi/maps/home0/map1.yaml` and `map1.pgm` exist.
+3. `POST /api/dashboard/maps/<sn>/active-slot {slot: 1}` → expect 200,
+   followed by `swap_active_map_respond {result: 0}` in
+   `extended_commands.log` and a `LoadMap` line in `map_server.log`.
+4. `POST /api/dashboard/command/<sn>
+    {command:{start_navigation:{area: 0, cutterhigh: 2, cmd_num: <ts>}}}`
+   → mower drives the 2nd polygon.
+5. Repeat with `slot: 0` to verify swap-back.
+
+## Failure Modes
+
+| Failure | Behaviour |
+|---|---|
+| Slot file missing on mower | 400, error names the missing slot, app surfaces "map N never physically mapped — map it via the app first". |
+| Coverage active during swap | 409, app surfaces "stop mowing first". No file changes. |
+| Disk-write failure (read-only fs, low storage) | 400 with copy error, no partial state because copies use `.tmp + os.replace`. |
+| `LoadMap` ROS call fails | 500 with stderr tail. `map.yaml` is already the requested slot (so a manual reload would still work) — the user can retry. |
+| Mower offline before swap | 404. |
+| Mower disconnects mid-swap | 504. Server cache NOT updated, so next attempt retries. |
+| Server restart wipes `deviceCache` | Idempotency is lost (we'll always swap on first request after restart) — acceptable: swap is fast when files unchanged. |
+
+## Anti-Patterns
+
+- **Don't synthesize yaml/pgm server-side.** Wrong origin or
+  resolution sends the mower to the wrong physical spot. If the slot
+  is missing on the mower, fail loud.
+- **Don't swap during active coverage.** Reloading `map.yaml`
+  mid-task corrupts the nav state and triggers Error 140-class
+  crashes. The mower handler refuses; the app must respect the 409.
+- **Don't extend the `area` enum.** Pretending area=10000 means
+  "slot 4" couples us to a firmware behaviour we never validated. The
+  swap renders the enum irrelevant — keep `area: 0` and own the slot
+  state server-side.
+- **Don't skip the LoadMap call.** Just rewriting the files isn't
+  enough — the running `map_server` keeps serving the previously
+  loaded grid until reload.
+- **Don't trust the server cache as ground truth.** The cache speeds up
+  idempotency but a manual rollback (mower SSH `cp`, a `sync_map` from
+  the admin panel, a reboot) can desync it. The cache is a hint,
+  not authority — when in doubt the user can force a fresh swap by
+  explicitly re-selecting the map. A future enhancement can read the
+  active slot back from a marker file (e.g. `home0/.active_slot`)
+  the handler writes after a successful copy.
+
+## Operator Runbook
+
+1. App / dashboard: pick the work map you want to mow.
+2. App calls `setActiveMapSlot(sn, slot)` if the cached
+   `active_map_slot` differs.
+3. Server publishes `swap_active_map`; mower copies files + reloads
+   `map_server`.
+4. App sends `start_navigation` with `area: 0`. Mower mowes the just-
+   swapped map.
+5. To switch maps without stopping the queue: ensure the previous mow
+   reaches `Work:FINISHED` first (handler's coverage-active guard
+   blocks otherwise).

--- a/docs/superpowers/specs/2026-05-04-multi-map-swap-active-slot.md
+++ b/docs/superpowers/specs/2026-05-04-multi-map-swap-active-slot.md
@@ -239,6 +239,29 @@ low-value).
   active slot back from a marker file (e.g. `home0/.active_slot`)
   the handler writes after a successful copy.
 
+## TODO before implementation
+
+**Confirm firmware accepts `mapName: "mapN"` for N ≥ 3.** Novabot
+Flutter's `_getMapName()` caps at "map2" (3-map UI limit). Firmware
+side is unknown — `mqtt_node` reads `mapName` literally with no
+visible validation in the decompile. Empirical test required:
+
+1. Patch our OpenNova app's mapping screen so `_getMapName()`
+   equivalent returns `"map3"` when 3 maps already exist.
+2. Walk a 4th work area on the mower via BLE.
+3. SSH `/userdata/lfi/maps/home0/` — verify `map3_work.csv`,
+   `map3.yaml`, `map3.pgm`, `map3.png` were generated.
+4. If yes → swap-flow design as written works for arbitrary N.
+5. If no → firmware caps internally. Two fallbacks:
+   - Reverse-engineer the cap in `mqtt_node`/`novabot_mapping`
+     binary (find where the `MAX_MAPS=3` check lives) and patch.
+   - Activate open `mqtt_node` (already exists at `mower/mqtt_node/`)
+     + intercept `add_scan_map` to multiplex into virtual slots.
+
+The implementation plan must NOT assume the empirical test passed.
+Plan task 0 is "run the test, document result". Subsequent tasks
+branch on outcome.
+
 ## Operator Runbook
 
 1. App / dashboard: pick the work map you want to mow.

--- a/research/extended_commands.py
+++ b/research/extended_commands.py
@@ -1991,8 +1991,8 @@ COMMANDS = {
     "blade_off": handle_blade_off,
     "blade_speed": handle_blade_speed,
     "blade_height": handle_blade_height,
-    "swap_active_map": lambda p, r: handle_swap_active_map(p, r),
     "sync_map": lambda p, r: handle_sync_map(p, r),
+    "swap_active_map": lambda p, r: handle_swap_active_map(p, r),
 }
 
 
@@ -2352,6 +2352,10 @@ def handle_swap_active_map(params, respond):
         })
         return
 
+    # Two-phase atomic copy: first stage all .tmp files, then commit via
+    # os.replace. If staging fails partway, clean up any .tmp leftovers
+    # and bail before mutating map.* — the active slot stays consistent.
+    staged = []  # list of (tmp_path, final_path) to commit on success
     try:
         for src, dst_name in (
             (src_yaml, "map.yaml"),
@@ -2362,8 +2366,17 @@ def handle_swap_active_map(params, respond):
                 continue  # png is optional; yaml/pgm checked above
             tmp = f"{home}/{dst_name}.tmp"
             shutil.copy2(src, tmp)
-            os.replace(tmp, f"{home}/{dst_name}")
+            staged.append((tmp, f"{home}/{dst_name}"))
+        # All copies succeeded — commit atomically.
+        for tmp, final in staged:
+            os.replace(tmp, final)
     except Exception as e:
+        # Cleanup any staged .tmp files that didn't get committed.
+        for tmp, _ in staged:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
         respond("swap_active_map_respond", {
             "result": 1,
             "error": f"copy failed: {e}",
@@ -2371,17 +2384,18 @@ def handle_swap_active_map(params, respond):
         })
         return
 
-    cmd = (
-        ". /opt/ros/galactic/setup.bash && "
-        ". /root/novabot/install/setup.bash && "
-        "export ROS_LOCALHOST_ONLY=1 && "
-        "ros2 service call /map_server/load_map nav2_msgs/srv/LoadMap "
-        f'"{{map_url: \\"{home}/map.yaml\\"}}"'
-    )
+    # Use ros2_run() so the RMW_IMPLEMENTATION + ROS_LOCALHOST_ONLY env
+    # matches every other ROS2 service call in this file. Without that
+    # the call may fail to discover /map_server on the running graph.
     try:
-        rc = subprocess.run(
-            ["bash", "-lc", cmd],
-            capture_output=True, text=True, timeout=15,
+        rc = ros2_run(
+            [
+                "ros2", "service", "call",
+                "/map_server/load_map",
+                "nav2_msgs/srv/LoadMap",
+                f'"{{map_url: \\"{home}/map.yaml\\"}}"',
+            ],
+            timeout=15,
         )
     except subprocess.TimeoutExpired:
         respond("swap_active_map_respond", {

--- a/research/extended_commands.py
+++ b/research/extended_commands.py
@@ -1991,6 +1991,7 @@ COMMANDS = {
     "blade_off": handle_blade_off,
     "blade_speed": handle_blade_speed,
     "blade_height": handle_blade_height,
+    "swap_active_map": lambda p, r: handle_swap_active_map(p, r),
     "sync_map": lambda p, r: handle_sync_map(p, r),
 }
 
@@ -2299,6 +2300,108 @@ def _restart_auto_recharge_server():
         return rc.returncode in (0, 1)
     except Exception:
         return False
+
+
+def handle_swap_active_map(params, respond):
+    """Copy mapN.{yaml,pgm,png} over the active map.{yaml,pgm,png} slot
+    and reload the nav stack via /map_server/load_map. Lifts the stock
+    firmware's effective 3-map limit (see docs/superpowers/specs/
+    2026-05-04-multi-map-swap-active-slot.md).
+
+    Result codes:
+      0 = success
+      1 = bad request (negative/missing slot) or copy failure
+      2 = requested slot was never mapped on this mower
+      3 = coverage is active — refuse mid-task
+      4 = files copied but LoadMap ROS call failed
+    """
+    import os
+    import shutil
+    import subprocess
+
+    slot_raw = params.get("slot", -1)
+    try:
+        slot = int(slot_raw)
+    except (TypeError, ValueError):
+        respond("swap_active_map_respond",
+                {"result": 1, "error": f"slot must be integer, got {slot_raw!r}"})
+        return
+    if slot < 0:
+        respond("swap_active_map_respond",
+                {"result": 1, "error": "slot must be non-negative"})
+        return
+
+    home = "/userdata/lfi/maps/home0"
+    src_yaml = f"{home}/map{slot}.yaml"
+    src_pgm = f"{home}/map{slot}.pgm"
+    src_png = f"{home}/map{slot}.png"
+
+    if not (os.path.exists(src_yaml) and os.path.exists(src_pgm)):
+        respond("swap_active_map_respond", {
+            "result": 2,
+            "error": f"map{slot} not mapped on this mower (yaml/pgm missing)",
+            "slot": slot,
+        })
+        return
+
+    if _coverage_is_active():
+        respond("swap_active_map_respond", {
+            "result": 3,
+            "error": "coverage active, swap refused — stop the running task first",
+            "slot": slot,
+        })
+        return
+
+    try:
+        for src, dst_name in (
+            (src_yaml, "map.yaml"),
+            (src_pgm, "map.pgm"),
+            (src_png, "map.png"),
+        ):
+            if not os.path.exists(src):
+                continue  # png is optional; yaml/pgm checked above
+            tmp = f"{home}/{dst_name}.tmp"
+            shutil.copy2(src, tmp)
+            os.replace(tmp, f"{home}/{dst_name}")
+    except Exception as e:
+        respond("swap_active_map_respond", {
+            "result": 1,
+            "error": f"copy failed: {e}",
+            "slot": slot,
+        })
+        return
+
+    cmd = (
+        ". /opt/ros/galactic/setup.bash && "
+        ". /root/novabot/install/setup.bash && "
+        "export ROS_LOCALHOST_ONLY=1 && "
+        "ros2 service call /map_server/load_map nav2_msgs/srv/LoadMap "
+        f'"{{map_url: \\"{home}/map.yaml\\"}}"'
+    )
+    try:
+        rc = subprocess.run(
+            ["bash", "-lc", cmd],
+            capture_output=True, text=True, timeout=15,
+        )
+    except subprocess.TimeoutExpired:
+        respond("swap_active_map_respond", {
+            "result": 4,
+            "error": "LoadMap ros2 service call timed out (15s)",
+            "slot": slot,
+        })
+        return
+
+    if rc.returncode != 0:
+        respond("swap_active_map_respond", {
+            "result": 4,
+            "error": "LoadMap call failed",
+            "load_rc": rc.returncode,
+            "load_stderr": rc.stderr[-200:] if rc.stderr else None,
+            "slot": slot,
+        })
+        return
+
+    respond("swap_active_map_respond", {"result": 0, "slot": slot})
 
 
 def _rerun_set_server_urls():

--- a/server/src/__tests__/routes/dashboardActiveSlot.test.ts
+++ b/server/src/__tests__/routes/dashboardActiveSlot.test.ts
@@ -163,6 +163,16 @@ describe('POST /api/dashboard/maps/:sn/active-slot', () => {
       .send({ slot: 1 });
     expect(r.status).toBe(500);
   });
+
+  it('translates mower result:1 (mower-side copy failure) to 500', async () => {
+    ackWith({ result: 1, error: 'copy failed: [Errno 28] No space left on device' });
+    const r = await request(app)
+      .post(`/api/dashboard/maps/${SN}/active-slot`)
+      .send({ slot: 1 });
+    expect(r.status).toBe(500);
+    expect(r.body.ok).toBe(false);
+    expect(String(r.body.error)).toContain('copy failed');
+  });
 });
 
 describe('GET /api/dashboard/maps/:sn/active-slot', () => {

--- a/server/src/__tests__/routes/dashboardActiveSlot.test.ts
+++ b/server/src/__tests__/routes/dashboardActiveSlot.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../mqtt/broker.js', () => ({
+  isDeviceOnline: vi.fn().mockReturnValue(true),
+  writeRawPublish: vi.fn().mockReturnValue(false),
+  getBrokerDiagnostics: vi.fn().mockReturnValue({}),
+  startMqttBroker: vi.fn(),
+  banishSn: vi.fn(),
+  unbanSn: vi.fn(),
+  listBannedSns: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock('../../dashboard/socketHandler.js', () => ({
+  getRecentLogs: vi.fn().mockReturnValue([]),
+  forwardToDashboard: vi.fn(),
+  onLogEntry: vi.fn(),
+  emitMapsChanged: vi.fn(),
+  emitDeviceOnline: vi.fn(),
+  emitDeviceOffline: vi.fn(),
+  emitTrailClear: vi.fn(),
+  emitCoveredLanes: vi.fn(),
+  setDemoModeChecker: vi.fn(),
+  setOutlineEmitter: vi.fn(),
+  initBleLogger: vi.fn(),
+  sendBleLogHistory: vi.fn(),
+  pushMqttLog: vi.fn(),
+  emitOtaEvent: vi.fn(),
+  emitPinEvent: vi.fn(),
+  emitExtendedEvent: vi.fn(),
+  emitCommandRespond: vi.fn(),
+  emitScheduleEvent: vi.fn(),
+}));
+
+vi.mock('../../mqtt/mapSync.js', async () => {
+  const actual = await vi.importActual<typeof import('../../mqtt/mapSync.js')>(
+    '../../mqtt/mapSync.js',
+  );
+  return {
+    ...actual,
+    publishToExtended: vi.fn(),
+    onExtendedResponse: vi.fn(),
+    offExtendedResponse: vi.fn(),
+    publishToDevice: vi.fn(),
+    publishRawToDevice: vi.fn(),
+  };
+});
+
+vi.mock('../../mqtt/sensorData.js', () => ({
+  deviceCache: new Map<string, Map<string, string>>(),
+  getAllDeviceSnapshots: vi.fn().mockReturnValue([]),
+  getDeviceSnapshot: vi.fn(),
+  SENSORS: [],
+  getGpsTrail: vi.fn().mockReturnValue([]),
+  clearGpsTrail: vi.fn(),
+  getLocalTrail: vi.fn().mockReturnValue([]),
+  clearLocalTrail: vi.fn(),
+  translateValue: vi.fn((_k: string, v: string) => v),
+  markPinVerified: vi.fn(),
+  getDockPose: vi.fn().mockReturnValue(null),
+}));
+
+import { dashboardRouter } from '../../routes/dashboard.js';
+import { isDeviceOnline } from '../../mqtt/broker.js';
+import * as mapSync from '../../mqtt/mapSync.js';
+import { deviceCache } from '../../mqtt/sensorData.js';
+
+const SN = 'LFIN1231000211';
+
+const app = express();
+app.use(express.json());
+app.use('/api/dashboard', dashboardRouter);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(isDeviceOnline).mockReturnValue(true);
+  vi.mocked(mapSync.offExtendedResponse).mockImplementation(() => {});
+  deviceCache.clear();
+});
+
+function ackWith(respond: Record<string, unknown>) {
+  vi.mocked(mapSync.onExtendedResponse).mockImplementation((_sn, handler) => {
+    queueMicrotask(() => handler({ swap_active_map_respond: respond } as any));
+  });
+}
+
+describe('POST /api/dashboard/maps/:sn/active-slot', () => {
+  it('publishes swap_active_map and returns 200 on result:0', async () => {
+    ackWith({ result: 0, slot: 3 });
+    const r = await request(app)
+      .post(`/api/dashboard/maps/${SN}/active-slot`)
+      .send({ slot: 3 });
+    expect(r.status).toBe(200);
+    expect(r.body).toMatchObject({ ok: true, slot: 3 });
+    expect(mapSync.publishToExtended).toHaveBeenCalledWith(
+      SN,
+      expect.objectContaining({ swap_active_map: { slot: 3 } }),
+    );
+    expect(deviceCache.get(SN)?.get('active_map_slot')).toBe('3');
+  });
+
+  it('idempotent: 2nd POST same slot is cached, no MQTT', async () => {
+    if (!deviceCache.has(SN)) deviceCache.set(SN, new Map());
+    deviceCache.get(SN)!.set('active_map_slot', '2');
+
+    const r = await request(app)
+      .post(`/api/dashboard/maps/${SN}/active-slot`)
+      .send({ slot: 2 });
+    expect(r.status).toBe(200);
+    expect(r.body).toMatchObject({ ok: true, slot: 2, cached: true });
+    expect(mapSync.publishToExtended).not.toHaveBeenCalled();
+  });
+
+  it('rejects negative slot with 400 and no MQTT', async () => {
+    const r = await request(app)
+      .post(`/api/dashboard/maps/${SN}/active-slot`)
+      .send({ slot: -1 });
+    expect(r.status).toBe(400);
+    expect(mapSync.publishToExtended).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-integer slot with 400', async () => {
+    const r = await request(app)
+      .post(`/api/dashboard/maps/${SN}/active-slot`)
+      .send({ slot: 'two' });
+    expect(r.status).toBe(400);
+    expect(mapSync.publishToExtended).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when mower offline', async () => {
+    vi.mocked(isDeviceOnline).mockReturnValue(false);
+    const r = await request(app)
+      .post(`/api/dashboard/maps/${SN}/active-slot`)
+      .send({ slot: 0 });
+    expect(r.status).toBe(404);
+  });
+
+  it('translates mower result:2 (slot not mapped) to 400 with helpful error', async () => {
+    ackWith({ result: 2, error: 'map5 not mapped on this mower (yaml/pgm missing)', slot: 5 });
+    const r = await request(app)
+      .post(`/api/dashboard/maps/${SN}/active-slot`)
+      .send({ slot: 5 });
+    expect(r.status).toBe(400);
+    expect(r.body.ok).toBe(false);
+    expect(String(r.body.error)).toContain('map first via the app');
+    expect(deviceCache.get(SN)?.has('active_map_slot')).toBe(false);
+  });
+
+  it('translates mower result:3 (coverage active) to 409', async () => {
+    ackWith({ result: 3, error: 'coverage active, swap refused' });
+    const r = await request(app)
+      .post(`/api/dashboard/maps/${SN}/active-slot`)
+      .send({ slot: 1 });
+    expect(r.status).toBe(409);
+    expect(String(r.body.error)).toContain('stop mowing first');
+  });
+
+  it('translates mower result:4 (LoadMap fail) to 500', async () => {
+    ackWith({ result: 4, error: 'LoadMap call failed', load_rc: 1 });
+    const r = await request(app)
+      .post(`/api/dashboard/maps/${SN}/active-slot`)
+      .send({ slot: 1 });
+    expect(r.status).toBe(500);
+  });
+});
+
+describe('GET /api/dashboard/maps/:sn/active-slot', () => {
+  it('returns the cached slot or null', async () => {
+    let r = await request(app).get(`/api/dashboard/maps/${SN}/active-slot`);
+    expect(r.status).toBe(200);
+    expect(r.body).toEqual({ slot: null });
+
+    if (!deviceCache.has(SN)) deviceCache.set(SN, new Map());
+    deviceCache.get(SN)!.set('active_map_slot', '4');
+    r = await request(app).get(`/api/dashboard/maps/${SN}/active-slot`);
+    expect(r.body).toEqual({ slot: 4 });
+  });
+});

--- a/server/src/routes/dashboard.ts
+++ b/server/src/routes/dashboard.ts
@@ -2338,6 +2338,105 @@ dashboardRouter.get('/rain-sessions/:sn', (req: Request, res: Response) => {
   res.json({ sessions });
 });
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Active map slot — multi-map support (>3 work maps).
+// Spec: docs/superpowers/specs/2026-05-04-multi-map-swap-active-slot.md
+//
+// POST /api/dashboard/maps/:sn/active-slot { slot: number }
+//   Tells the mower to copy mapN.{yaml,pgm,png} over the active map.* slot
+//   and reload the nav stack. Idempotent — second call with the same slot
+//   is satisfied from the deviceCache.
+//
+// GET /api/dashboard/maps/:sn/active-slot
+//   Returns the cached active slot (or null when never set).
+// ─────────────────────────────────────────────────────────────────────────────
+
+dashboardRouter.post('/maps/:sn/active-slot', async (req: Request, res: Response) => {
+  const { sn } = req.params;
+  const slotRaw = (req.body as { slot?: unknown }).slot;
+  if (typeof slotRaw !== 'number' || !Number.isInteger(slotRaw) || slotRaw < 0) {
+    res.status(400).json({ ok: false, error: 'slot must be a non-negative integer' });
+    return;
+  }
+  const slot = slotRaw;
+
+  if (!isDeviceOnline(sn)) {
+    res.status(404).json({ ok: false, error: 'Device is offline' });
+    return;
+  }
+
+  // Ensure a cache entry exists for this device so callers can reliably check
+  // .has('active_map_slot') after a failed swap (returns false, not undefined).
+  if (!deviceCache.has(sn)) deviceCache.set(sn, new Map());
+
+  // Idempotency: if cache says we're already on this slot, skip MQTT.
+  const cached = deviceCache.get(sn)!.get('active_map_slot');
+  if (cached === String(slot)) {
+    res.json({ ok: true, slot, cached: true });
+    return;
+  }
+
+  const { publishToExtended, onExtendedResponse, offExtendedResponse } =
+    await import('../mqtt/mapSync.js');
+
+  type Result = { ok: boolean; respond?: Record<string, unknown>; timeout?: boolean };
+  const result = await new Promise<Result>(resolve => {
+    let settled = false;
+    const handler = (data: Record<string, unknown>) => {
+      const r = data.swap_active_map_respond as Record<string, unknown> | undefined;
+      if (!r || settled) return;
+      settled = true;
+      offExtendedResponse(sn, handler);
+      resolve({ ok: r.result === 0, respond: r });
+    };
+    onExtendedResponse(sn, handler);
+    publishToExtended(sn, { swap_active_map: { slot } });
+    setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      offExtendedResponse(sn, handler);
+      resolve({ ok: false, timeout: true });
+    }, 15000);
+  });
+
+  if (result.timeout) {
+    res.status(504).json({ ok: false, error: 'mower did not ack within 15s', slot });
+    return;
+  }
+  if (result.ok) {
+    deviceCache.get(sn)!.set('active_map_slot', String(slot));
+    forwardToDashboard(sn, new Map([['active_map_slot', String(slot)]]));
+    res.json({ ok: true, slot, respond: result.respond });
+    return;
+  }
+
+  // Translate mower error codes to HTTP statuses.
+  const code = (result.respond?.result as number | undefined) ?? -1;
+  const mowerErr = String(result.respond?.error ?? 'swap failed');
+  if (code === 2) {
+    res.status(400).json({
+      ok: false,
+      error: `${mowerErr} — map first via the app`,
+      respond: result.respond,
+    });
+  } else if (code === 3) {
+    res.status(409).json({
+      ok: false,
+      error: `${mowerErr} — stop mowing first`,
+      respond: result.respond,
+    });
+  } else if (code === 4) {
+    res.status(500).json({ ok: false, error: mowerErr, respond: result.respond });
+  } else {
+    res.status(400).json({ ok: false, error: mowerErr, respond: result.respond });
+  }
+});
+
+dashboardRouter.get('/maps/:sn/active-slot', (req: Request, res: Response) => {
+  const cached = deviceCache.get(req.params.sn)?.get('active_map_slot');
+  res.json({ slot: cached != null ? parseInt(cached, 10) : null });
+});
+
 // POST /api/dashboard/rain-ignore-session/:sn — user vinkte "Negeer regen
 // deze sessie" aan in StartMowSheet. Server slaat per-mower vlag op die de
 // rain monitor doet skippen tot de sessie eindigt (work_status terug naar

--- a/server/src/routes/dashboard.ts
+++ b/server/src/routes/dashboard.ts
@@ -2425,6 +2425,11 @@ dashboardRouter.post('/maps/:sn/active-slot', async (req: Request, res: Response
       error: `${mowerErr} — stop mowing first`,
       respond: result.respond,
     });
+  } else if (code === 1) {
+    // Mower-side disk write failure (shutil.copy2 / os.replace). This is
+    // a server-side infrastructure problem, NOT a client bug — return 500
+    // so callers don't treat a transient mower fs issue as their own fault.
+    res.status(500).json({ ok: false, error: mowerErr, respond: result.respond });
   } else if (code === 4) {
     res.status(500).json({ ok: false, error: mowerErr, respond: result.respond });
   } else {

--- a/server/src/services/scheduleRunner.ts
+++ b/server/src/services/scheduleRunner.ts
@@ -8,7 +8,7 @@
 
 import { scheduleRepo, mapRepo, messageRepo } from '../db/repositories/index.js';
 import { isDeviceOnline } from '../mqtt/broker.js';
-import { publishToDevice } from '../mqtt/mapSync.js';
+import { publishToExtended, onExtendedResponse, offExtendedResponse } from '../mqtt/mapSync.js';
 import { startMowing } from './mowingService.js';
 import { getWeatherForecast, shouldPauseForRain } from './weatherService.js';
 import { emitScheduleEvent } from '../dashboard/socketHandler.js';
@@ -148,8 +148,6 @@ function triggerSchedule(row: ScheduleRow) {
   if (slot != null) {
     void (async () => {
       try {
-        const { publishToExtended, onExtendedResponse, offExtendedResponse } =
-          await import('../mqtt/mapSync.js');
         await new Promise<void>(resolve => {
           let settled = false;
           const handler = (data: Record<string, unknown>) => {
@@ -170,14 +168,17 @@ function triggerSchedule(row: ScheduleRow) {
       } catch (err) {
         console.error(`[ScheduleRunner] swap_active_map failed for ${row.mower_sn} slot=${slot}:`, err);
       }
-      runStartMowing(row);
+      // Swap completed (success or timeout — the mower may have
+      // partially loaded the new map either way). Use area=0 so the
+      // legacy enum doesn't fight the post-swap state.
+      runStartMowing(row, 0);
     })();
     return;
   }
   runStartMowing(row);
 }
 
-function runStartMowing(row: ScheduleRow) {
+function runStartMowing(row: ScheduleRow, areaOverride?: number) {
   // Bereken effectieve richting (met alternerende rotatie)
   let effectiveDirection = row.path_direction;
   if (row.alternate_direction === 1) {
@@ -190,7 +191,10 @@ function runStartMowing(row: ScheduleRow) {
     sn: row.mower_sn,
     cuttingHeight: row.cutting_height ?? 5,
     pathDirection: effectiveDirection,
-    area: 1,
+    // After a successful slot swap the loaded map.yaml IS the requested
+    // map — area is irrelevant, so caller passes 0. Legacy schedules
+    // without a slot swap stay on area=1 (matches old behavior).
+    area: areaOverride ?? 1,
   });
   console.log(`[ScheduleRunner] ${row.schedule_id}: ${result.ok ? 'started' : 'FAILED: ' + result.error} (height=${row.cutting_height}, dir=${effectiveDirection})`);
 

--- a/server/src/services/scheduleRunner.ts
+++ b/server/src/services/scheduleRunner.ts
@@ -23,6 +23,18 @@ function getChargerGps(mowerSn: string): { lat: number; lng: number } | null {
   return mapRepo.getChargerGps(mowerSn);
 }
 
+/** Resolve the firmware slot index from the schedule's stored mapId.
+ *  Reads canonical_name on the maps row and parses the trailing
+ *  digits ("map7_work" -> 7). Returns null when the row is missing or
+ *  the canonical_name doesn't match. */
+function resolveSlotForSchedule(row: ScheduleRow): number | null {
+  if (!row.map_id) return null;
+  const mapRow = mapRepo.findById(row.map_id);
+  const canonical = mapRow?.canonical_name ?? '';
+  const m = canonical.match(/^map(\d+)/);
+  return m ? parseInt(m[1], 10) : null;
+}
+
 function getScheduleOccurrence(row: ScheduleRow, now: Date): Date | null {
   const weekdays: number[] = JSON.parse(row.weekdays);
   const currentDay = now.getDay(); // 0=Sunday
@@ -128,6 +140,44 @@ async function checkWeatherAndTrigger(
 }
 
 function triggerSchedule(row: ScheduleRow) {
+  // Multi-map support: ensure the mower has the right slot loaded into
+  // its active map.yaml before kicking off the mow. Skips when the
+  // schedule is bound to a slot we can't resolve (legacy rows). Spec:
+  // docs/superpowers/specs/2026-05-04-multi-map-swap-active-slot.md
+  const slot = resolveSlotForSchedule(row);
+  if (slot != null) {
+    void (async () => {
+      try {
+        const { publishToExtended, onExtendedResponse, offExtendedResponse } =
+          await import('../mqtt/mapSync.js');
+        await new Promise<void>(resolve => {
+          let settled = false;
+          const handler = (data: Record<string, unknown>) => {
+            if (!data.swap_active_map_respond || settled) return;
+            settled = true;
+            offExtendedResponse(row.mower_sn, handler);
+            resolve();
+          };
+          onExtendedResponse(row.mower_sn, handler);
+          publishToExtended(row.mower_sn, { swap_active_map: { slot } });
+          setTimeout(() => {
+            if (settled) return;
+            settled = true;
+            offExtendedResponse(row.mower_sn, handler);
+            resolve();  // never block the mow on swap timeout
+          }, 15000);
+        });
+      } catch (err) {
+        console.error(`[ScheduleRunner] swap_active_map failed for ${row.mower_sn} slot=${slot}:`, err);
+      }
+      runStartMowing(row);
+    })();
+    return;
+  }
+  runStartMowing(row);
+}
+
+function runStartMowing(row: ScheduleRow) {
   // Bereken effectieve richting (met alternerende rotatie)
   let effectiveDirection = row.path_direction;
   if (row.alternate_direction === 1) {


### PR DESCRIPTION
## Summary
- New \`swap_active_map\` extended-command handler on the mower copies \`mapN.{yaml,pgm,png}\` over the active slot via two-phase atomic copy and reloads \`map_server\` via \`ros2_run\` (consistent ROS env).
- New server endpoint \`POST /api/dashboard/maps/:sn/active-slot\` orchestrates the swap with idempotency caching (\`deviceCache.active_map_slot\`) and proper error code translation (mower result:0/1/2/3/4 → HTTP 200/500/400/409/500).
- App + dashboard + scheduleRunner pre-swap the active slot before every \`start_navigation\` and use \`area: 0\` post-swap, so any work map (canonical \`mapN\`) can be mowed regardless of the legacy 1/10/200 area enum.

Spec: \`docs/superpowers/specs/2026-05-04-multi-map-swap-active-slot.md\`
Plan: \`docs/superpowers/plans/2026-05-04-multi-map-swap-active-slot.md\`

## What's NOT in this PR
- Live deploy to the test mower — TODO: SCP \`research/extended_commands.py\` to \`/root/novabot/scripts/\` + restart daemon, then verify swap → curl confirmation → real mow on slot 1.
- App's BLE mapping screen still caps at 3 maps in the UI (\`_getMapName()\` cap). Lifting that requires a separate change. This PR only enables MOWING on slots 3+ that already exist on the mower.

## Test plan
- [x] \`cd server && npx vitest run\` — 297/297 passing (10 new active-slot cases)
- [x] \`cd app && npx tsc --noEmit\` — clean
- [x] \`cd dashboard && npx tsc --noEmit\` — clean
- [ ] Acceptance test on LFIN1231000211: SCP extended_commands.py → restart → \`curl POST /maps/<sn>/active-slot {slot:1}\` → \`cmp /userdata/lfi/maps/home0/map.yaml /userdata/lfi/maps/home0/map1.yaml\` returns 0
- [ ] Real mow on slot 1 from the OpenNova app drives the right polygon

## Firmware scan note
robot_decision binary (\`mappingSaveMapDeal\` at 0x7e000) shows a \`cmp w0, #0x9\` against what's likely the map count, with a fall-through path that logs + likely rejects. Hypothesis: firmware caps internally at 9 maps. Not empirically confirmed; the swap flow itself works for any N where mapN.{yaml,pgm} files exist on disk.