### PR TITLE
feat(dashboard): render missed_points as orange circle markers on the…

### DIFF
--- a/dashboard/src/components/map/MowerMap.tsx
+++ b/dashboard/src/components/map/MowerMap.tsx
@@ -2749,6 +2749,28 @@ export function MowerMap({ sn, lat, lng, mapX, mapY, heading, mowingActive, prog
   })();
   const trailPositions: [number, number][] = trailSegments.flat();
 
+  // Missed points — local meter coordinates from sensors.missed_points
+  // Format: "x1 y1;x2 y2;..." (semicolon-separated, space-delimited x y pairs)
+  // Uses the same localToGps + calibration transform as the GPS trail.
+  const missedPointsGps: [number, number][] = (() => {
+    const raw = mowingSensors.missed_points;
+    if (!raw || !isUsableChargerGps(chargerGps)) return [];
+    const offLat = Number.isFinite(activeCal.offsetLat) ? activeCal.offsetLat : 0;
+    const offLng = Number.isFinite(activeCal.offsetLng) ? activeCal.offsetLng : 0;
+    const result: [number, number][] = [];
+    for (const part of raw.split(';')) {
+      const [xs, ys] = part.trim().split(/\s+/);
+      const x = parseFloat(xs);
+      const y = parseFloat(ys);
+      if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+      const g = localToGps({ x: x - (chargingPose?.x ?? 0), y: y - (chargingPose?.y ?? 0) }, chargerGps);
+      const lat = g.lat + offLat;
+      const lng = g.lng + offLng;
+      if (Number.isFinite(lat) && Number.isFinite(lng)) result.push([lat, lng]);
+    }
+    return result;
+  })();
+
   // Mower heading icon — `heading` carries the firmware `theta` field in
   // radians using the ENU convention (0 = East, π/2 = North). The icon
   // helper expects compass degrees (0 = North, 90 = East), so we have to
@@ -3237,6 +3259,24 @@ export function MowerMap({ sn, lat, lng, mapX, mapY, heading, mowingActive, prog
               );
             });
           })()}
+          {/* Missed points — orange circles for positions the mower skipped
+              during coverage. Shown together with the GPS trail toggle so they
+              appear / disappear alongside the session-progress overlay. */}
+          {showTrail && missedPointsGps.map((pos, i) => (
+            <CircleMarker
+              key={`missed-${i}`}
+              center={pos}
+              radius={5}
+              pathOptions={{
+                color: '#f97316',
+                fillColor: '#f97316',
+                fillOpacity: 0.85,
+                weight: 1.5,
+              }}
+            >
+              <Tooltip sticky>{t('map.missedPoint', 'Missed point')}</Tooltip>
+            </CircleMarker>
+          ))}
           {/* Live outline during autonomous mapping (report_state_map_outline) */}
           {liveOutline && liveOutline.length >= 3 && (
             <Polygon

--- a/dashboard/src/i18n/locales/de.json
+++ b/dashboard/src/i18n/locales/de.json
@@ -236,6 +236,7 @@
     "toolDock": "Dock",
     "toolShow": "Anzeigen",
     "clearTrail": "Spur löschen",
+    "missedPoint": "Verpasster Punkt",
     "noGoZone": "Sperrzone",
     "sat": "Sat",
     "streetMap": "Karte",

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -252,6 +252,7 @@
     "toolDock": "Dock",
     "toolShow": "Show",
     "clearTrail": "Clear trail",
+    "missedPoint": "Missed point",
     "noGoZone": "No-go zone",
     "sat": "Sat",
     "streetMap": "Map",

--- a/dashboard/src/i18n/locales/fr.json
+++ b/dashboard/src/i18n/locales/fr.json
@@ -236,6 +236,7 @@
     "toolDock": "Dock",
     "toolShow": "Afficher",
     "clearTrail": "Effacer la trace",
+    "missedPoint": "Point manqué",
     "noGoZone": "Zone interdite",
     "sat": "Sat",
     "streetMap": "Plan",

--- a/dashboard/src/i18n/locales/nl.json
+++ b/dashboard/src/i18n/locales/nl.json
@@ -299,6 +299,7 @@
     "toolDock": "Dock",
     "toolShow": "Tonen",
     "clearTrail": "Trail wissen",
+    "missedPoint": "Gemist punt",
     "noGoZone": "No-go zone",
     "sat": "Sat",
     "streetMap": "Kaart",

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '../api/client';
 import { readWeekStart, writeWeekStart, type WeekStart } from '../utils/weekStart';
 import { readTimeFormat, writeTimeFormat, type TimeFormat } from '../utils/timeFormat';
+import { writeMowDefaults } from '../utils/mowDefaults';
 import { MowingDirectionPreview } from '../components/schedule/MowingDirectionPreview';
 import { useToast } from '../components/common/Toast';
 
@@ -280,16 +281,21 @@ function MowerSettingsSection({ mower }: { mower: DeviceState }) {
     if (got) {
       hydrated.current = true;
       const c = committedRef.current;
+      const newCh = ch ?? c.cuttingHeight;
+      const newPd = pd ?? c.pathDirection;
       committedRef.current = {
         ...c,
-        cuttingHeight: ch ?? c.cuttingHeight,
+        cuttingHeight: newCh,
         sensitivity: ob ?? c.sensitivity,
-        pathDirection: pd ?? c.pathDirection,
+        pathDirection: newPd,
         joystickSpeed: jv ?? c.joystickSpeed,
         joystickHandling: jw ?? c.joystickHandling,
         headlight: hl ?? c.headlight,
         sound: so ?? c.sound,
       };
+      // Keep mowDefaults in sync so MowerControls pre-fills with the mower's
+      // actual configured cutting height / direction (fixes issue #105).
+      writeMowDefaults({ cuttingHeight: newCh, pathDirection: newPd });
     }
   }, [mower.sensors]);
 
@@ -321,6 +327,7 @@ function MowerSettingsSection({ mower }: { mower: DeviceState }) {
           headlight, brightness, sound, timezone,
         };
         writeBrightness(brightness);
+        writeMowDefaults({ cuttingHeight, pathDirection });
         setSavedTick(x => x + 1);
       } catch {
         toast(`✗ ${t('settings.mower.saveFailed', 'Could not save settings')}`, 'error');


### PR DESCRIPTION
* feat: render missed_points as orange circle markers on dashboard map. fixes https://github.com/rvbcrs/Novabot/discussions/74

During an active mowing session, sensor data includes missed_points (format: "x y;x y;..." in local meter frame, same as cover_path.covered.missed).

Changes:
- Parse sensors.missed_points into GPS coordinates using the same localToGps + calibration transform as the GPS trail
- Render each missed point as an orange CircleMarker (radius 5, #f97316) with a sticky tooltip, shown when showTrail is true (same toggle as the GPS trail so they appear/disappear together)
- Add i18n key map.missedPoint across en/nl/de/fr locales

---------

Added fix: manual mow cut height defaults to configured setting (issue https://github.com/rvbcrs/Novabot/issues/105)
also tested in my dev dashboard.